### PR TITLE
Player firing and weapon cooldown

### DIFF
--- a/src/objects/Player.js
+++ b/src/objects/Player.js
@@ -41,7 +41,7 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
     }
 
     update(powerbarCurrent) {
-        this.powerbarCurrent = 1;
+        this.powerbarCurrent = powerbarCurrent;
 
         if (this.spaceKey.isDown && this.powerbarCurrent > 0) {
             this.isLanding = true;

--- a/src/objects/Player.js
+++ b/src/objects/Player.js
@@ -1,7 +1,7 @@
 import 'phaser';
 
 export default class Player extends Phaser.Physics.Arcade.Sprite {
-    constructor(scene, x, y, sprite, radius) {
+    constructor(scene, x, y, sprite, radius, plasmaField) {
         super(scene, x, y, sprite);
         this.scene = scene;
         this.x = x;
@@ -14,6 +14,7 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
         this.currentAngle = 270;
         this.isLanding = false;
         this.movementSpeed = 2;
+        this.plasmaField = plasmaField;
 
         this.cursors = this.scene.input.keyboard.createCursorKeys();
         this.spaceKey = this.scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
@@ -42,9 +43,23 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
         if (this.spaceKey.isDown) {
             this.isLanding = true;
             this.setHover(0);
+            this.plasmaField.startFiring(
+                Phaser.Math.RadToDeg(
+                    Phaser.Math.Angle.Between(
+                        512,
+                        383,
+                        this.x,
+                        this.y
+                    )
+                ));
+            this.plasmaField.isFiring = true;
         } else if (this.spaceKey.isUp) {
             this.isLanding = false;
             this.setHover(this.defaultOrbitHoverDistance);
+            if (this.plasmaField.isFiring) {
+                this.plasmaField.stopFiring();
+                this.plasmaField.isFiring = false;
+            }
         }
 
         if (this.cursors.left.isDown) {

--- a/src/objects/Player.js
+++ b/src/objects/Player.js
@@ -15,6 +15,7 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
         this.isLanding = false;
         this.movementSpeed = 2;
         this.plasmaField = plasmaField;
+        this.powerbarCurrent = 0;
 
         this.cursors = this.scene.input.keyboard.createCursorKeys();
         this.spaceKey = this.scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
@@ -39,8 +40,10 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
         this.y = this.center.y + this.orbitDistance * Math.sin(Phaser.Math.DegToRad(this.currentAngle));
     }
 
-    update(time, delta) {
-        if (this.spaceKey.isDown) {
+    update(powerbarCurrent) {
+        this.powerbarCurrent = 1;
+
+        if (this.spaceKey.isDown && this.powerbarCurrent > 0) {
             this.isLanding = true;
             this.setHover(0);
             this.plasmaField.startFiring(

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -13,6 +13,7 @@ var graphicsHealthbar;
 var rectangleHealthbar;
 var healthbarCurrent;
 var healthbarMax;
+var plasmaConsumeRate = 4;
 
 export class Game extends Scene
 {
@@ -26,25 +27,6 @@ export class Game extends Scene
 
         this.plasmaField = new PlasmaField(this);
         this.plasmaField.isFiring = false;
-
-        this.input.on('pointerdown', () => {
-            if (!this.plasmaField.isFiring) {
-                this.plasmaField.startFiring(
-                    Phaser.Math.RadToDeg(
-                        Phaser.Math.Angle.Between(
-                            512,
-                            383,
-                            this.input.mousePointer.x,
-                            this.input.mousePointer.y
-                        )
-                    )
-                );
-                this.plasmaField.isFiring = true;
-            } else {
-                this.plasmaField.stopFiring();
-                this.plasmaField.isFiring = false;
-            }
-        });
 
         this.core = this.physics.add.staticImage(512, 380, 'station');
 
@@ -156,7 +138,7 @@ export class Game extends Scene
         // }
 
         if (this.plasmaField.isFiring) {
-            powerbarCurrent = Math.max(0, powerbarCurrent - 10);
+            powerbarCurrent = Math.max(0, powerbarCurrent - plasmaConsumeRate);
         }
 
         this.addEnemy();

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -25,10 +25,10 @@ export class Game extends Scene
         this.add.image(512, 384, 'background');
 
         this.plasmaField = new PlasmaField(this);
-        this.plasmaIsFiring = false;
+        this.plasmaField.isFiring = false;
 
         this.input.on('pointerdown', () => {
-            if (!this.plasmaIsFiring) {
+            if (!this.plasmaField.isFiring) {
                 this.plasmaField.startFiring(
                     Phaser.Math.RadToDeg(
                         Phaser.Math.Angle.Between(
@@ -39,10 +39,10 @@ export class Game extends Scene
                         )
                     )
                 );
-                this.plasmaIsFiring = true;
+                this.plasmaField.isFiring = true;
             } else {
                 this.plasmaField.stopFiring();
-                this.plasmaIsFiring = false;
+                this.plasmaField.isFiring = false;
             }
         });
 
@@ -113,7 +113,8 @@ export class Game extends Scene
             this.shield.x,
             this.shield.y, 
             'player',
-            this.shield.height / 2
+            this.shield.height / 2,
+            this.plasmaField
         );
         this.player.setDepth(5);
 
@@ -154,7 +155,7 @@ export class Game extends Scene
         //     healthbarCurrent = Math.min(healthbarMax, healthbarCurrent + 5);
         // }
 
-        if (this.plasmaIsFiring) {
+        if (this.plasmaField.isFiring) {
             powerbarCurrent = Math.max(0, powerbarCurrent - 10);
         }
 

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -114,7 +114,7 @@ export class Game extends Scene
             this.shield.y, 
             'player',
             this.shield.height / 2,
-            this.plasmaField
+            this.plasmaField,
         );
         this.player.setDepth(5);
 
@@ -145,7 +145,7 @@ export class Game extends Scene
     }
 
     update () {
-        this.player.update();
+        this.player.update(powerbarCurrent);
       
         // Currently constantly increases power and health
         if (powerbarCurrent < powerbarMax){

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -59,6 +59,18 @@ export class Game extends Scene
 
         this.makeShapeMask(rectanglePowerbar, graphicsPowerbar);
 
+        this.powerbarMinimum = 100;
+        this.graphicsPowerbarMinimum = this.add.graphics ({ fillStyle: {color: 0xff0000, alpha: 0.5}});
+        this.graphicsPowerbarMinimum.fillRect(
+            this.powerbarForeground.getBottomLeft().x,
+            this.powerbarForeground.getBottomLeft().y - this.powerbarMinimum,
+            this.powerbarForeground.width,
+            this.powerbarMinimum
+        );
+        this.graphicsPowerbarMinimum.setDepth(4);
+
+        this.makeShapeMask(rectanglePowerbar, this.graphicsPowerbarMinimum);
+
         // Add Health bar
         graphicsHealthbar = this.add.graphics({ fillStyle: { color: 0xe54489 }});
         graphicsHealthbar.setDepth(4);
@@ -97,6 +109,7 @@ export class Game extends Scene
             'player',
             this.shield.height / 2,
             this.plasmaField,
+            graphicsPowerbar
         );
         this.player.setDepth(5);
 


### PR DESCRIPTION
Plasma tendrils will move to the target location before triggering enemy destruction. There is still some minor delay but it is improved.

Adds a cooldown feature which causes the player to be unable to fire for short time if the power level drops to 0.

An warning zone is rendered on the powerbar to indicate that this may be a danger zone. Powerbar flashes red during the cooldown period and stops when a minimum amount of energy has been restored.