### PR TITLE
Gradually ramp up difficulty

### DIFF
--- a/src/objects/EnemySpawnManager.js
+++ b/src/objects/EnemySpawnManager.js
@@ -1,0 +1,127 @@
+import 'phaser';
+import Util from '../util.js';
+
+export default class EnemySpawnManager {
+    constructor(scene) {
+        this.scene = scene;
+
+        this.spawnRates = [
+            {name: "small",
+             timer: null,
+             cb: this.scene.addSmallShip,
+             dt: 55},
+            {name: "health",
+             timer: null,
+             cb: this.scene.addHealthShip,
+             dt: 5000},
+            {name: "big",
+             timer: null,
+             cb: this.scene.addBigShip,
+             dt: 4000}
+        ];
+
+        this.updateSpawnTimers();
+
+        // this feels good, our music is ~3:20, which is 200 seconds,
+        // so 10 ramps 20 seconds apart?
+        this.maxRamps = 10;
+        this.rampDelay = 20000;
+        
+        this.rampTimer = this.scene.time.addEvent({
+            delay: this.rampDelay,
+            repeat: this.maxRamps,
+            callback: () => {
+                this.rampUp();
+            },
+            callbackScopr: this
+        });
+
+        this.patterns = new Map();
+        this.patterns.set('circle', {spawn: this.spawnCircle});
+        this.patterns.set('spiral', {spawn: this.spawnSpiral});
+        this.patterns.set('doubleCircle', {spawn: this.spawnDoubleCircle});
+        this.patterns.set('doubleSpiral', {spawn: this.spawnDoubleSpiral});
+        this.patternCount = 0;
+
+        this.patternTimer = this.scene.time.addEvent({
+            delay: this.rampDelay,
+            callback: (scene) => {
+                let pattern = Util.randNth(Array.from(this.patterns.keys()));
+                if (this.patternCount < 4) {
+                    pattern = ['circle', 'spiral', 'doubleCircle', 'doubleSpiral'][this.patternCount];
+                }
+                this.spawnPattern(
+                    scene,
+                    pattern
+                );
+                this.patternCount++;
+            },
+            callbackScope: this,
+            args: [this.scene],
+            loop: true
+        });
+    }
+
+    /**
+     * Remove the old timers and create new ones based on (presumably)
+     * updated spawnRates.
+     */
+    updateSpawnTimers() {
+        this.spawnRates.forEach(({timer, cb, dt, n}, i, spawnRates) => {
+            if (timer !== null) {
+                spawnRates[i].timer.remove();
+            }
+            spawnRates[i].timer = this.scene.time.addEvent({
+                delay: Math.floor(dt),
+                callback: cb,
+                callbackScope: this.scene,
+                loop: true
+            });
+        });
+    }
+
+    /**
+     * Make the delays between spawns shorter and make the number of
+     * entities spawned larger.
+     * 
+     * The timers use Math.floor on `dt` and `n`, so they wont
+     * necessarily change every time.
+     */
+    rampUp() {
+        this.spawnRates.forEach((rate) => {
+            rate.dt *= 0.9;
+            rate.n *= 1.1;
+        });
+        this.updateSpawnTimers();
+    }
+
+    spawnPattern(scene, name) {
+        this.patterns.get(name).spawn(scene);
+    }
+
+    spawnCircle(scene) {
+        for (let i = 0; i < 360; i++) {
+            scene.addSmallShip(i);
+        }
+    }
+
+    spawnSpiral(scene) {
+        for (let i = 0; i < 360; i++) {
+            scene.addSmallShip((i * 2), 700 + i * 2);
+        }
+    }
+
+    spawnDoubleCircle(scene) {
+        for (let i = 0; i < 360; i++) {
+            scene.addSmallShip(i);
+            scene.addSmallShip(i, 740);
+        }
+    }
+
+    spawnDoubleSpiral(scene) {
+        for (let i = 0; i < 360; i++) {
+            scene.addSmallShip((i * 2), 700 + i);
+            scene.addSmallShip((i * 2) + 180, 700 + i * 2);
+        }
+    }
+}

--- a/src/objects/PlasmaField.js
+++ b/src/objects/PlasmaField.js
@@ -125,7 +125,6 @@ export default class PlasmaField extends Phaser.GameObjects.Container {
         }
     }
 
-    // @TODO: we should make the wiggles straighter when firing so the tendrils will easily fit through our cannon aperture.
     startFiring(angle) {
         if (angle < 0) {
             this.firingAngle = angle + 360;

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -2,6 +2,7 @@ import { Scene } from 'phaser';
 import Player from '../objects/Player';
 import Shield from '../objects/Shield';
 import PlasmaField from '../objects/PlasmaField';
+import EnemySpawnManager from '../objects/EnemySpawnManager';
 import Util from '../util.js';
 
 var keys;
@@ -108,13 +109,6 @@ export class Game extends Scene
         );
         this.player.setDepth(5);
 
-        var healthShiptimer = this.time.addEvent({
-            delay: 5000,
-            callback: this.addHealthShip,
-            callbackScope: this,
-            loop: true
-        });
-
         this.healthShips = this.physics.add.group();
         this.anims.create({
             key: 'explode',
@@ -124,12 +118,6 @@ export class Game extends Scene
         this.physics.add.overlap(this.shieldSurface, this.healthShips, this.healthShipHitShield, this.outerShieldCollisionProcessor, this);
         this.physics.add.overlap(this.player, this.healthShips, this.collectHealthShip, null, this);
 
-        var bigShiptimer = this.time.addEvent({
-            delay: 4000,
-            callback: this.addBigShip,
-            callbackScope: this,
-            loop: true
-        });
         this.bigShips = this.physics.add.group();
         this.physics.add.overlap(this.shieldSurface, this.bigShips, this.bigShipHitShield, this.outerShieldCollisionProcessor, this);
 
@@ -148,7 +136,11 @@ export class Game extends Scene
                 this.useBomb();
                 this.bombs.pop().destroy();
             }
-            
+        });
+
+        this.rKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.R);
+        this.rKey.on('down', ()=> {
+            this.spawner.spawnPattern(this, Util.randNth(Array.from(this.spawner.patterns.keys())));
         });
 
         this.tendrilCollider = this.physics.add.overlap(this.plasmaField, this.destroyableShips, this.hitTendril, this.plasmaField.collisionProcessor, this);
@@ -159,6 +151,9 @@ export class Game extends Scene
         this.scoreText = this.add.text(16, 46, 'score: 0', { fontSize: '32px', fill: '#FFF' });
         this.scoreText.setDepth(5);
         this.score = 0;
+
+        // Manage ramping difficulty and stuff
+        this.spawner = new EnemySpawnManager(this);
     }
 
     update () {
@@ -175,8 +170,6 @@ export class Game extends Scene
         if (this.plasmaField.isFiring && !this.plasmaField.isFiringFullScreen) {
             powerbarCurrent = Math.max(0, powerbarCurrent - plasmaConsumeRate);
         }
-
-        this.addSmallShip();
 
         this.plasmaField.update();
         this.plasmaField.draw();
@@ -215,28 +208,38 @@ export class Game extends Scene
         graphicsType.setMask(mask);
     }
 
-    addShip(sprite){
+    addShip(sprite, spawnAngle = null, distance = null) {
+        if (spawnAngle == null) {
+            spawnAngle = Util.randBetween(0, 360);
+        }
+        spawnAngle = Util.mod(spawnAngle, 360);
+
+        if (distance == null) {
+            distance = 700;
+        }
+
         this.start = new Phaser.Math.Vector2(512, 384);
-        let spawnAngle = Util.randBetween(0, 360);
-        this.randomCirclePos = Util.offsetByTrig(this.start, spawnAngle, 700); //start, angle, distance
+        this.circlePos = Util.offsetByTrig(this.start, spawnAngle, distance); //start, angle, distance
         var ship = this.physics.add.sprite(
-            this.randomCirclePos.x, 
-            this.randomCirclePos.y, 
+            this.circlePos.x,
+            this.circlePos.y,
             sprite
         );
         ship.setDepth(1);
         ship.spawnAngle = spawnAngle;
 
         // rotate to face centre
-        const angleDeg = Math.atan2(this.randomCirclePos.y - this.core.y, this.randomCirclePos.x - this.core.x) * 180 / Math.PI;
+        const angleDeg = Math.atan2(this.circlePos.y - this.core.y, this.circlePos.x - this.core.x) * 180 / Math.PI;
         ship.angle = angleDeg-90;
         this.destroyableShips.add(ship);
         return ship;
     }
 
-    addSmallShip(){
-        var smallShip = this.addShip('smallShip');
+    addSmallShip(spawnAngle = null, distance = null) {
+        let smallShip = this.addShip('smallShip', spawnAngle, distance);
+        smallShip.shipType = 'small';
         smallShip.scoreValue = 5;
+        smallShip.coreDamage = 10;
         this.smallShips.add(smallShip);
         this.physics.moveToObject(smallShip, this.core, 50);
     }
@@ -254,15 +257,27 @@ export class Game extends Scene
     }
 
     hitCore(core, ship) {
-        // @TODO: shake screen?
-        // @TODO: die??
+        healthbarCurrent = Math.max(0, healthbarCurrent - ship.coreDamage);
+        switch (ship.shipType) {
+            case 'small':
+                this.cameras.main.shake(100, 0.005);
+                break;
+            case 'health':
+                this.cameras.main.shake(100, 0.01);
+                break;
+            case 'big':
+                this.cameras.main.shake(200, 0.03);
+                break;
+        }
         // @TODO: animate ship death?
         ship.destroy();
     }
 
-    addHealthShip(){
+    addHealthShip() {
         var healthShip = this.addShip('healthShipExplosion');
+        healthShip.shipType = 'health';
         healthShip.scoreValue = 0;
+        healthShip.coreDamage = 20;
         this.healthShips.add(healthShip);
         this.physics.moveToObject(healthShip, this.core, 40);
     }
@@ -286,9 +301,11 @@ export class Game extends Scene
         // TODO: Add some nice animation or flurry of green/pink plusses
     }
 
-    addBigShip(){
+    addBigShip() {
         var bigShip = this.addShip('bigShip');
+        bigShip.shipType = 'big';
         bigShip.scoreValue = 100;
+        bigShip.coreDamage = 200;
         this.bigShips.add(bigShip);
         this.physics.moveToObject(bigShip, this.core, 40);
     }


### PR DESCRIPTION
Increase the spawn rates of all types of ships every 20 seconds (max of 10 times).

Also add spawning pattern of small ships every time we ramp up, this required modifying the ship spawning functions to take optional spawnAngle and distance parameters.

Make it so when ships hit the core it damages us more than normal and shakes the camera.