### PR TITLE
simplified the logic for the power bar a bit

### DIFF
--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -62,7 +62,7 @@ export class Game extends Scene
 
         this.makeShapeMask(rectanglePowerbar, graphicsPowerbar);
 
-        this.powerbarMinimum = 100;
+        this.powerbarMinimum = 120;
         this.graphicsPowerbarMinimum = this.add.graphics ({ fillStyle: {color: 0xff0000, alpha: 0.7}});
         this.graphicsPowerbarMinimum.fillRect(
             this.powerbarForeground.getBottomLeft().x,


### PR DESCRIPTION
Removed the cooldown state, and instead just rely on the depleted flag. If you hit the bottom it#s depleted, starts flashing, you cant fire. once above minimum it's no longer depleted.

Gives roughly the same behaviour as intended, but has simpler if statements and seems to behave more consistently.